### PR TITLE
Update gnome runtime

### DIFF
--- a/net.lugsole.bible_gui.json
+++ b/net.lugsole.bible_gui.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "net.lugsole.bible_gui",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "43",
+    "runtime-version" : "44",
     "sdk" : "org.gnome.Sdk",
     "command" : "bible",
     "finish-args" : [


### PR DESCRIPTION
Gnome runtime 43 would also be ok, but I bump this to 44 in order to draw attention. The reason is that the repo flathub/net.lugsole.bible_gui is still on 42 and it seems like action is needed to bump it to 43 or 44, as 42 is end-of-life. Thanks! :)